### PR TITLE
Add a few tests against PyCO2SYS

### DIFF
--- a/seaflux/fco2_pco2_conversion.py
+++ b/seaflux/fco2_pco2_conversion.py
@@ -161,8 +161,8 @@ def virial_coeff(temp_K, pres_atm, xCO2_mol=None):
 
     Parameters
     ----------
-    press_hPa : np.array
-        uncorrected pressure in hPa
+    press_atm : np.array
+        uncorrected pressure in atm
     temp_K : np.array
         temperature in degrees Kelvin
     xCO2_mol : np.array

--- a/tests/test_PyCO2SYS.py
+++ b/tests/test_PyCO2SYS.py
@@ -9,15 +9,51 @@ import seaflux as sf, PyCO2SYS as pyco2, numpy as np
 rng = np.random.default_rng(7)
 npts = 1000
 
+# Set generic test conditions
+salinity = np.array([*rng.uniform(low=0, high=50, size=npts - 1), 0])
+temperature = np.array([-2, 0, *rng.uniform(low=-2, high=45, size=npts - 2)])  # deg-C
+pCO2_or_fCO2 = rng.uniform(low=1, high=1000, size=npts)  # microatm
+pres_atm = 1  # atm
+
+# Convert units
+temperature_K = temperature + 273.15  # K
+
 
 def test_vapour_pressure_weiss1980():
-    # Set test conditions
-    salinity = np.array([*rng.uniform(low=0, high=50, size=npts), 0, 35])
-    temperature = np.array([-2, 0, *rng.uniform(low=-2, high=45, size=npts)])
-    # Convert units
-    temperature_K = temperature + 273.15
     # Calculate vapour pressures of H2O
     vpf_seaflux = sf.vapour_pressure.weiss1980(salinity, temperature_K)
     vpf_pyco2 = 1 - pyco2.gas.vpfactor(temperature, salinity)
     # Compare results - should be virtually identical
     assert np.all(np.isclose(vpf_seaflux, vpf_pyco2, rtol=1e-12, atol=0))
+
+
+def test_virial_coefficient():
+    # Calculate fugacity factors
+    fugfac_seaflux = sf.fco2_pco2_conversion.virial_coeff(temperature_K, pres_atm)
+    fugfac_pyco2 = pyco2.sys(2100, 8.1, 2, 3, temperature=temperature)[
+        "fugacity_factor"
+    ]
+    # Compare results
+    assert np.all(np.isclose(fugfac_seaflux, fugfac_pyco2, rtol=0, atol=1e-7))
+
+
+def test_pCO2_to_fCO2_conversion():
+    # Convert pCO2 to fCO2
+    fCO2_pyco2 = pyco2.sys(pCO2_or_fCO2, 8.1, 4, 3, temperature=temperature)["fCO2"]
+    fCO2_seaflux = sf.pCO2_to_fCO2(pCO2_or_fCO2, temperature)
+    # Compare results - not perfect agreement, but "good enough"(?) i.e. <0.01 microatm
+    not_nan = ~np.isnan(fCO2_seaflux)
+    assert np.all(
+        np.isclose(fCO2_pyco2[not_nan], fCO2_seaflux[not_nan], rtol=0, atol=0.01)
+    )
+
+
+def test_fCO2_to_pCO2_conversion():
+    # Convert fCO2 to pCO2
+    pCO2_pyco2 = pyco2.sys(pCO2_or_fCO2, 8.1, 5, 3, temperature=temperature)["pCO2"]
+    pCO2_seaflux = sf.fCO2_to_pCO2(pCO2_or_fCO2, temperature)
+    # Compare results - not perfect agreement, but "good enough"(?) i.e. <0.01 microatm
+    not_nan = ~np.isnan(pCO2_seaflux)
+    assert np.all(
+        np.isclose(pCO2_pyco2[not_nan], pCO2_seaflux[not_nan], rtol=0, atol=0.01)
+    )

--- a/tests/test_PyCO2SYS.py
+++ b/tests/test_PyCO2SYS.py
@@ -1,0 +1,23 @@
+# Tests against PyCO2SYS (originally v1.6.0).
+#
+# Weiss (1974) CO2 solubility cannot be directly tested because PyCO2SYS evaluates this
+# in /kg units while SeaFlux uses /l units.
+
+import seaflux as sf, PyCO2SYS as pyco2, numpy as np
+
+# Seed random number generator for reproducibility
+rng = np.random.default_rng(7)
+npts = 1000
+
+
+def test_vapour_pressure_weiss1980():
+    # Set test conditions
+    salinity = np.array([*rng.uniform(low=0, high=50, size=npts), 0, 35])
+    temperature = np.array([-2, 0, *rng.uniform(low=-2, high=45, size=npts)])
+    # Convert units
+    temperature_K = temperature + 273.15
+    # Calculate vapour pressures of H2O
+    vpf_seaflux = sf.vapour_pressure.weiss1980(salinity, temperature_K)
+    vpf_pyco2 = 1 - pyco2.gas.vpfactor(temperature, salinity)
+    # Compare results - should be virtually identical
+    assert np.all(np.isclose(vpf_seaflux, vpf_pyco2, rtol=1e-12, atol=0))


### PR DESCRIPTION
Hoi, this just adds a few numerical tests against PyCO2SYS for some of the more obvious things that both packages calculate.

A couple of things come out very close, but not exactly the same, and it looks like there are some updates available on some of the equations in PyCO2SYS inherited from older CO2SYS versions. It would be great to incorporate these as options in PyCO2SYS too and get better agreement between the two.

I have not updated the repo configuration files and settings required to make these tests pass (i.e. adding PyCO2SYS to the environment), sorry, as I'm not totally sure how to do this correctly.